### PR TITLE
Add Hosted Plugin Manager

### DIFF
--- a/examples/electron/package.json
+++ b/examples/electron/package.json
@@ -35,7 +35,8 @@
     "@theia/typescript": "^0.3.8",
     "@theia/userstorage": "^0.3.8",
     "@theia/variable-resolver": "^0.3.8",
-    "@theia/workspace": "^0.3.8"
+    "@theia/workspace": "^0.3.8",
+    "@theia/plugin": "^0.3.8"
   },
   "scripts": {
     "prepare": "yarn run clean && yarn build",

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -2,13 +2,20 @@
   "name": "@theia/plugin",
   "version": "0.3.8",
   "description": "Theia - Plugin API",
-  "types": "./src/theia.d.ts",
+  "main": "lib/common/index.js",
+  "typings": "lib/common/index.d.ts",
+  "dependencies": {
+    "@theia/core": "^0.3.8",
+    "@theia/filesystem": "^0.3.8",
+    "@theia/workspace": "^0.3.8"
+  },
   "publishConfig": {
     "access": "public"
   },
   "theiaExtensions": [
     {
-      "backend": "lib/node/plugin-api-backend-module",
+      "backend": "lib/node/node-plugin-api-backend-module",
+      "backendElectron": "lib/node-electron/electron-plugin-api-backend-module",
       "frontend": "lib/browser/plugin-api-frontend-module"
     }
   ],
@@ -44,4 +51,3 @@
     "extends": "../../configs/nyc.json"
   }
 }
-

--- a/packages/plugin/src/browser/hosted-plugin-manager-client.ts
+++ b/packages/plugin/src/browser/hosted-plugin-manager-client.ts
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { injectable, inject } from 'inversify';
+import URI from '@theia/core/lib/common/uri';
+import { MessageService } from '@theia/core/lib/common';
+import { LabelProvider, isNative } from '@theia/core/lib/browser';
+import { WindowService } from '@theia/core/lib/browser/window/window-service';
+import { WorkspaceService } from '@theia/workspace/lib/browser';
+import { FileSystem } from '@theia/filesystem/lib/common';
+import { FileDialogFactory, DirNode } from '@theia/filesystem/lib/browser';
+import { HostedPluginServer } from '../common/plugin-protocol';
+import { HostedPluginCommands } from './plugin-api-frontend-contribution';
+
+/**
+ * Responsible for UI to set up and control Hosted Plugin Instance.
+ */
+@injectable()
+export class HostedPluginManagerClient {
+    @inject(HostedPluginServer)
+    protected readonly hostedPluginServer: HostedPluginServer;
+    @inject(MessageService)
+    protected readonly messageService: MessageService;
+    @inject(FileDialogFactory)
+    protected readonly fileDialogFactory: FileDialogFactory;
+    @inject(LabelProvider)
+    protected readonly labelProvider: LabelProvider;
+    @inject(WindowService)
+    protected readonly windowService: WindowService;
+    @inject(FileSystem)
+    protected readonly fileSystem: FileSystem;
+    @inject(WorkspaceService)
+    protected readonly workspaceService: WorkspaceService;
+
+    protected pluginLocation: URI | undefined;
+    protected pluginInstanceUri: string | undefined;
+
+    async start(): Promise<void> {
+        if (!this.pluginLocation) {
+            await this.selectPluginPath();
+            if (!this.pluginLocation) {
+                // selection was cancelled
+                return;
+            }
+        }
+        try {
+            this.messageService.info('Starting hosted instance server ...');
+            await this.doRunRequest(this.pluginLocation);
+            this.messageService.info('Hosted instance is running at: ' + this.pluginInstanceUri);
+        } catch (error) {
+            this.messageService.error('Failed to run hosted plugin instance: ' + this.getErrorMessage(error));
+        }
+    }
+
+    async stop(): Promise<void> {
+        try {
+            await this.hostedPluginServer.terminateHostedPluginInstance();
+            this.messageService.info((this.pluginInstanceUri ? this.pluginInstanceUri : 'The instance') + ' has been terminated.');
+        } catch (error) {
+            this.messageService.warn(this.getErrorMessage(error));
+        }
+    }
+
+    async restart(): Promise<void> {
+        if (await this.hostedPluginServer.isHostedTheiaRunning()) {
+            await this.stop();
+
+            this.messageService.info('Starting hosted instance server ...');
+            // It takes some time before OS released all resources e.g. port.
+            // Keeping tries to run hosted instance with delay.
+            let lastError;
+            for (let tries = 0; tries < 15; tries++) {
+                try {
+                    await this.doRunRequest(this.pluginLocation!);
+                    this.messageService.info('Hosted instance is running at: ' + this.pluginInstanceUri);
+                    return;
+                } catch (error) {
+                    lastError = error;
+                    await new Promise(resolve => setTimeout(resolve, 500));
+                }
+            }
+            this.messageService.error('Failed to run hosted plugin instance: ' + this.getErrorMessage(lastError));
+        } else {
+            this.messageService.warn('Hosted Plugin instance is not running.');
+        }
+    }
+
+    /**
+     * Creates directory choose dialog and set selected folder into pluginLocation field.
+     */
+    async selectPluginPath(): Promise<void> {
+        const root = await this.workspaceService.root || await this.fileSystem.getCurrentUserHome();
+        const rootUri = new URI(root.uri);
+        const rootStat = await this.fileSystem.getFileStat(rootUri.toString());
+        const name = this.labelProvider.getName(rootUri);
+        const label = await this.labelProvider.getIcon(root);
+        const rootNode = DirNode.createRoot(rootStat, name, label);
+        const dialog = this.fileDialogFactory({ title: HostedPluginCommands.SELECT_PLUGIN_PATH.label! });
+        dialog.model.navigateTo(rootNode);
+        const node = await dialog.open();
+        if (node) {
+            if (await this.hostedPluginServer.isPluginValid(node.uri.toString())) {
+                this.pluginLocation = node.uri;
+                this.messageService.info('Plugin folder is set to: ' + node.uri.toString());
+            } else {
+                this.messageService.error('Specified folder does not contain valid plugin.');
+            }
+        }
+    }
+
+    /**
+     * Send run command to backend. Throws an error if start failed.
+     * Sets hosted instance uri into pluginInstanceUri field.
+     *
+     * @param pluginLocation uri to plugin binaries
+     */
+    protected async doRunRequest(pluginLocation: URI): Promise<void> {
+        const uri = await this.hostedPluginServer.runHostedPluginInstance(pluginLocation.toString());
+        this.pluginInstanceUri = uri;
+        if (!isNative) {
+            // Open a new tab in case of browser
+            this.windowService.openNewWindow(uri);
+        }
+    }
+
+    protected getErrorMessage(error: Error): string {
+        return error.message.substring(error.message.indexOf(':') + 1);
+    }
+}

--- a/packages/plugin/src/browser/plugin-api-frontend-contribution.ts
+++ b/packages/plugin/src/browser/plugin-api-frontend-contribution.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { injectable, inject } from 'inversify';
+import { Command, CommandRegistry, CommandContribution } from '@theia/core/lib/common';
+import { HostedPluginManagerClient } from './hosted-plugin-manager-client';
+
+export namespace HostedPluginCommands {
+    export const RUN: Command = {
+        id: 'hosted-plugin:run',
+        label: 'Hosted Plugin: Start Instance'
+    };
+    export const TERMINATE: Command = {
+        id: 'hosted-plugin:terminate',
+        label: 'Hosted Plugin: Stop Instance'
+    };
+    export const RESTART: Command = {
+        id: 'hosted-plugin:restart',
+        label: 'Hosted Plugin: Restart Instance'
+    };
+    export const SELECT_PLUGIN_PATH: Command = {
+        id: 'hosted-plugin:select-path',
+        label: 'Hosted Plugin: Select Path'
+    };
+}
+
+@injectable()
+export class PluginApiFrontendContribution implements CommandContribution {
+
+    @inject(HostedPluginManagerClient)
+    protected readonly hostedPluginManagerClient: HostedPluginManagerClient;
+
+    registerCommands(commands: CommandRegistry): void {
+        commands.registerCommand(HostedPluginCommands.RUN, {
+            execute: () => this.hostedPluginManagerClient.start()
+        });
+        commands.registerCommand(HostedPluginCommands.TERMINATE, {
+            execute: () => this.hostedPluginManagerClient.stop()
+        });
+        commands.registerCommand(HostedPluginCommands.RESTART, {
+            execute: () => this.hostedPluginManagerClient.restart()
+        });
+        commands.registerCommand(HostedPluginCommands.SELECT_PLUGIN_PATH, {
+            execute: () => this.hostedPluginManagerClient.selectPluginPath()
+        });
+    }
+
+}

--- a/packages/plugin/src/browser/plugin-api-frontend-module.ts
+++ b/packages/plugin/src/browser/plugin-api-frontend-module.ts
@@ -6,18 +6,25 @@
  */
 import { ContainerModule } from "inversify";
 import { FrontendApplicationContribution, FrontendApplication } from "@theia/core/lib/browser";
-import { MaybePromise } from "@theia/core/lib/common";
+import { MaybePromise, CommandContribution } from "@theia/core/lib/common";
 import { WebSocketConnectionProvider } from '@theia/core/lib/browser/messaging';
 import { PluginWorker } from './plugin-worker';
 import { HostedPluginServer, hostedServicePath } from '../common/plugin-protocol';
 import { HostedPluginSupport } from './hosted-plugin';
 import { setUpPluginApi } from './main-context';
 import { HostedPluginWatcher } from './hosted-plugin-watcher';
+import { PluginApiFrontendContribution } from './plugin-api-frontend-contribution';
+import { HostedPluginManagerClient } from "./hosted-plugin-manager-client";
 
 export default new ContainerModule(bind => {
     bind(PluginWorker).toSelf().inSingletonScope();
     bind(HostedPluginSupport).toSelf().inSingletonScope();
     bind(HostedPluginWatcher).toSelf().inSingletonScope();
+    bind(HostedPluginManagerClient).toSelf().inSingletonScope();
+
+    bind(PluginApiFrontendContribution).toSelf().inSingletonScope();
+    bind(FrontendApplicationContribution).toDynamicValue(c => c.container.get(PluginApiFrontendContribution));
+    bind(CommandContribution).toDynamicValue(c => c.container.get(PluginApiFrontendContribution));
 
     bind(FrontendApplicationContribution).toDynamicValue(ctx => ({
         onStart(app: FrontendApplication): MaybePromise<void> {

--- a/packages/plugin/src/common/index.ts
+++ b/packages/plugin/src/common/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+export * from '../node/hosted-plugin-uri-postprocessor';

--- a/packages/plugin/src/common/plugin-protocol.ts
+++ b/packages/plugin/src/common/plugin-protocol.ts
@@ -138,4 +138,10 @@ export const HostedPluginServer = Symbol('HostedPluginServer');
 export interface HostedPluginServer extends JsonRpcServer<HostedPluginClient> {
     getHostedPlugin(): Promise<PluginMetadata | undefined>;
     onMessage(message: string): Promise<void>;
+
+    isPluginValid(uri: string): Promise<boolean>;
+    runHostedPluginInstance(uri: string): Promise<string>;
+    terminateHostedPluginInstance(): Promise<void>;
+    isHostedTheiaRunning(): Promise<boolean>;
+    getHostedPluginInstanceURI(): Promise<string>;
 }

--- a/packages/plugin/src/node-electron/electron-plugin-api-backend-module.ts
+++ b/packages/plugin/src/node-electron/electron-plugin-api-backend-module.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { ContainerModule } from "inversify";
+import { HostedPluginManager, ElectronNodeHostedPluginRunner } from '../node/hosted-plugin-manager';
+import { bindCommonPart } from "../node/plugin-api-backend-module";
+
+export default new ContainerModule(bind => {
+    bind(HostedPluginManager).to(ElectronNodeHostedPluginRunner);
+
+    bindCommonPart(bind);
+});

--- a/packages/plugin/src/node/hosted-plugin-manager.ts
+++ b/packages/plugin/src/node/hosted-plugin-manager.ts
@@ -1,0 +1,233 @@
+/*
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { inject, injectable, named } from "inversify";
+import * as cp from "child_process";
+import * as fs from "fs";
+import * as net from "net";
+import URI from '@theia/core/lib/common/uri';
+import { ContributionProvider } from "@theia/core/lib/common/contribution-provider";
+import { HostedPluginUriPostProcessor } from "./hosted-plugin-uri-postprocessor";
+
+export const HostedPluginManager = Symbol('HostedPluginManager');
+
+/**
+ * Is responsible for running and handling separate Theia instance with given plugin.
+ */
+export interface HostedPluginManager {
+    /**
+     * Checks whether hosted instance is run.
+     */
+    isRunning(): boolean;
+
+    /**
+     * Runs specified by the given uri plugin in separate Theia instance.
+     *
+     * @param pluginUri uri to the plugin source location
+     * @param port port on which new instance of Theia should be run. Optional.
+     * @returns uri where new Theia instance is run
+     */
+    run(pluginUri: URI, port?: number): Promise<URI>;
+
+    /**
+     * Terminates hosted plugin instance.
+     * Throws error if instance is not running.
+     */
+    terminate(): void;
+
+    /**
+     * Returns uri where hosted instance is run.
+     * Throws error if instance is not running.
+     */
+    getInstanceURI(): URI;
+
+    /**
+     * Checks whether given uri points to a valid plugin.
+     *
+     * @param uri uri to the plugin source location
+     */
+    isPluginValid(uri: URI): boolean;
+}
+
+const HOSTED_INSTANCE_START_TIMEOUT_MS = 30000;
+const THEIA_INSTANCE_REGEX = /.*Theia app listening on (.*)\. \[\].*/;
+const PROCESS_OPTIONS = {
+    cwd: process.cwd(),
+    env: { ...process.env }
+};
+delete PROCESS_OPTIONS.env.ELECTRON_RUN_AS_NODE;
+
+@injectable()
+export abstract class AbstractHostedPluginManager implements HostedPluginManager {
+    protected hostedInstanceProcess: cp.ChildProcess;
+    protected processOptions: cp.SpawnOptions;
+    protected isPluginRunnig: boolean = false;
+    protected instanceUri: URI;
+
+    constructor() {
+        this.isPluginRunnig = false;
+    }
+
+    isRunning(): boolean {
+        return this.isPluginRunnig;
+    }
+
+    async run(pluginUri: URI, port?: number): Promise<URI> {
+        if (this.isPluginRunnig) {
+            throw new Error('Hosted plugin instance is already running.');
+        }
+
+        let command: string[];
+        let processOptions: cp.SpawnOptions;
+        if (pluginUri.scheme === 'file') {
+            processOptions = { ...PROCESS_OPTIONS };
+            processOptions.env.HOSTED_PLUGIN = pluginUri.path.toString();
+            command = await this.getStartCommand(port);
+        } else {
+            throw new Error('Not supported plugin location: ' + pluginUri.toString());
+        }
+
+        this.instanceUri = await this.postProcessInstanceUri(
+            await this.runHostedPluginTheiaInstance(command, processOptions));
+        return this.instanceUri;
+    }
+
+    terminate(): void {
+        if (this.isPluginRunnig) {
+            this.hostedInstanceProcess.kill();
+        } else {
+            throw new Error('Hosted plugin instance is not running.');
+        }
+    }
+
+    getInstanceURI(): URI {
+        if (this.isPluginRunnig) {
+            return this.instanceUri;
+        }
+        throw new Error('Hosted plugin instance is not running.');
+    }
+
+    isPluginValid(uri: URI): boolean {
+        const packageJsonPath = uri.path.toString() + '/package.json';
+        if (fs.existsSync(packageJsonPath)) {
+            const packageJson = require(packageJsonPath);
+            const plugin = packageJson['theiaPlugin'];
+            if (plugin && (plugin['frontend'] || plugin['backend'])) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    protected async getStartCommand(port?: number): Promise<string[]> {
+        const command = ['yarn', 'theia', 'start'];
+        if (process.env.HOSTED_PLUGIN_HOSTNAME) {
+            command.push('--hostname=' + process.env.HOSTED_PLUGIN_HOSTNAME);
+        }
+        if (port) {
+            await this.validatePort(port);
+            command.push('--port=' + port);
+        }
+        return command;
+    }
+
+    protected async postProcessInstanceUri(uri: URI): Promise<URI> {
+        return uri;
+    }
+
+    protected runHostedPluginTheiaInstance(command: string[], options: cp.SpawnOptions): Promise<URI> {
+        this.isPluginRunnig = true;
+        return new Promise((resolve, reject) => {
+            let started = false;
+            const outputListener = (data: string | Buffer) => {
+                const line = data.toString();
+                const match = THEIA_INSTANCE_REGEX.exec(line);
+                if (match) {
+                    this.hostedInstanceProcess.stdout.removeListener('data', outputListener);
+                    started = true;
+                    resolve(new URI(match[1]));
+                }
+            };
+
+            this.hostedInstanceProcess = cp.spawn(command.shift()!, command, options);
+            this.hostedInstanceProcess.on('error', () => { this.isPluginRunnig = false; });
+            this.hostedInstanceProcess.on('exit', () => { this.isPluginRunnig = false; });
+            this.hostedInstanceProcess.stdout.addListener('data', outputListener);
+            setTimeout(() => {
+                if (!started) {
+                    this.hostedInstanceProcess.kill();
+                    this.isPluginRunnig = false;
+                    reject('Timeout.');
+                }
+            }, HOSTED_INSTANCE_START_TIMEOUT_MS);
+        });
+    }
+
+    protected async validatePort(port: number): Promise<void> {
+        if (port < 1 || port > 65535) {
+            throw new Error('Port value is incorrect.');
+        }
+
+        if (! await this.isPortFree(port)) {
+            throw new Error('Port ' + port + ' is already in use.');
+        }
+    }
+
+    protected isPortFree(port: number): Promise<boolean> {
+        return new Promise(resolve => {
+            const server = net.createServer();
+            server.listen(port, '0.0.0.0');
+            server.on('error', () => {
+                resolve(false);
+            });
+            server.on('listening', () => {
+                server.close();
+                resolve(true);
+            });
+        });
+    }
+
+}
+
+@injectable()
+export class NodeHostedPluginRunner extends AbstractHostedPluginManager {
+    @inject(ContributionProvider) @named(HostedPluginUriPostProcessor)
+    protected readonly uriPostProcessors: ContributionProvider<HostedPluginUriPostProcessor>;
+
+    protected async postProcessInstanceUri(uri: URI): Promise<URI> {
+        for (const uriPostProcessor of this.uriPostProcessors.getContributions()) {
+            uri = await uriPostProcessor.processUri(uri);
+        }
+        return uri;
+    }
+
+    protected async getStartCommand(port?: number): Promise<string[]> {
+        if (!port) {
+            if (process.env.HOSTED_PLUGIN_PORT) {
+                port = Number(process.env.HOSTED_PLUGIN_PORT);
+            } else {
+                port = 3030;
+            }
+        }
+        return super.getStartCommand(port);
+    }
+
+}
+
+@injectable()
+export class ElectronNodeHostedPluginRunner extends AbstractHostedPluginManager {
+    terminate(): void {
+        if (this.isPluginRunnig) {
+            // TODO fix it. In case of electron, this terminates only parent process while
+            // child processes detach and become child processes of systemd.
+            // See https://github.com/eclipse/che/issues/9367
+            this.hostedInstanceProcess.kill();
+        } else {
+            throw new Error('Hosted plugin instance is not running.');
+        }
+    }
+}

--- a/packages/plugin/src/node/hosted-plugin-uri-postprocessor.ts
+++ b/packages/plugin/src/node/hosted-plugin-uri-postprocessor.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import URI from "@theia/core/lib/common/uri";
+
+export const HostedPluginUriPostProcessor = Symbol('HostedPluginUriPostProcessor');
+export interface HostedPluginUriPostProcessor {
+    processUri(uri: URI): Promise<URI>;
+}

--- a/packages/plugin/src/node/node-plugin-api-backend-module.ts
+++ b/packages/plugin/src/node/node-plugin-api-backend-module.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { ContainerModule } from "inversify";
+import { bindContributionProvider } from "@theia/core/lib/common/contribution-provider";
+import { HostedPluginManager, NodeHostedPluginRunner } from './hosted-plugin-manager';
+import { bindCommonPart } from "./plugin-api-backend-module";
+import { HostedPluginUriPostProcessor } from "./hosted-plugin-uri-postprocessor";
+
+export default new ContainerModule(bind => {
+    bind(HostedPluginManager).to(NodeHostedPluginRunner).inSingletonScope();
+    bindContributionProvider(bind, HostedPluginUriPostProcessor);
+
+    bindCommonPart(bind);
+});

--- a/packages/plugin/src/node/plugin-api-backend-module.ts
+++ b/packages/plugin/src/node/plugin-api-backend-module.ts
@@ -5,7 +5,7 @@
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 
-import { ContainerModule } from "inversify";
+import { interfaces } from "inversify";
 import { ConnectionHandler, JsonRpcConnectionHandler } from "@theia/core/lib/common/messaging";
 import { BackendApplicationContribution } from '@theia/core/lib/node/backend-application';
 import { MetadataScanner } from './metadata-scanner';
@@ -16,7 +16,7 @@ import { HostedPluginSupport } from './hosted-plugin';
 import { TheiaPluginScanner } from './scanners/scanner-theia';
 import { VsCodePluginScanner } from './scanners/scanner-vscode';
 
-export default new ContainerModule(bind => {
+export function bindCommonPart(bind: interfaces.Bind): void {
     bind(PluginApiContribution).toSelf().inSingletonScope();
     bind(HostedPluginReader).toSelf().inSingletonScope();
     bind(HostedPluginServer).to(HostedPluginServerImpl).inSingletonScope();
@@ -36,4 +36,4 @@ export default new ContainerModule(bind => {
             return server;
         })
     ).inSingletonScope();
-});
+}


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

Adds Hosted Plugin Manager into Theia's plugin APi, which adds commands:
- Run Hosted Theia Instance
- Set path to the plugin under development
- Terminate Hosted Theia Instance
- Restart hosted instance

This PR adds separation between node and node-electron in plugin extension.

Part of https://github.com/eclipse/che/issues/9212
