### PR TITLE
Make plugin-ext npm module

### DIFF
--- a/packages/plugin-ext/README.md
+++ b/packages/plugin-ext/README.md
@@ -2,5 +2,8 @@
 
 See [here](https://github.com/theia-ide/theia) for a detailed documentation.
 
+## Contribution points:
+ - Hosted Istance uri post processor
+
 ## License
 [Apache-2.0](https://github.com/theia-ide/theia/blob/master/LICENSE)

--- a/packages/plugin-ext/package.json
+++ b/packages/plugin-ext/package.json
@@ -2,6 +2,8 @@
   "name": "@theia/plugin-ext",
   "version": "0.3.10",
   "description": "Theia - Plugin Extension",
+  "main": "lib/common/index.js",
+  "typings": "lib/common/index.d.ts",
   "dependencies": {
     "@theia/core": "^0.3.10",
     "@theia/filesystem": "^0.3.10",

--- a/packages/plugin-ext/src/common/index.ts
+++ b/packages/plugin-ext/src/common/index.ts
@@ -5,4 +5,6 @@
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 
+// Exports contribution point for uri postprocessor of hosted plugin manager.
+// This could be used to alter hosted instance uri, for example, change port.
 export * from '../hosted/node/hosted-plugin-uri-postprocessor';

--- a/packages/plugin-ext/src/common/index.ts
+++ b/packages/plugin-ext/src/common/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+export * from '../hosted/node/hosted-plugin-uri-postprocessor';


### PR DESCRIPTION
Adds typings and entrypoint into plugin-ext module. This allows using it as full npm module.
This export is needed for Che specific hosted plugin manager extension at least.