### PR TITLE
UI for manage Theia development mode

### DIFF
--- a/packages/plugin-ext/src/hosted/browser/hosted-plugin-informer.ts
+++ b/packages/plugin-ext/src/hosted/browser/hosted-plugin-informer.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { injectable, inject } from 'inversify';
+import { StatusBar } from '@theia/core/lib/browser/status-bar/status-bar';
+import { StatusBarAlignment, StatusBarEntry, FrontendApplicationContribution } from '@theia/core/lib/browser';
+import { WorkspaceService } from '@theia/workspace/lib/browser';
+import { HostedPluginServer } from '../../common/plugin-protocol';
+import { ConnectionStatusService, ConnectionState } from '@theia/core/lib/browser/connection-status-service';
+import URI from '@theia/core/lib/common/uri';
+import { FileStat } from '@theia/filesystem/lib/common';
+import { FrontendApplicationStateService } from '@theia/core/lib/browser/frontend-application-state';
+
+/**
+ * Informs the user whether Theia is running with hosted plugin.
+ * Adds 'Development Host' status bar element and appends the same prefix to window title.
+ */
+@injectable()
+export class HostedPluginInformer implements FrontendApplicationContribution {
+
+    public static readonly DEVELOPMENT_HOST_TITLE = "Development Host";
+
+    public static readonly DEVELOPMENT_HOST = "development-host";
+
+    public static readonly DEVELOPMENT_HOST_OFFLINE = "development-host-offline";
+
+    private entry: StatusBarEntry;
+
+    @inject(StatusBar)
+    protected readonly statusBar: StatusBar;
+
+    @inject(WorkspaceService)
+    protected readonly workspaceService: WorkspaceService;
+
+    @inject(HostedPluginServer)
+    protected readonly hostedPluginServer: HostedPluginServer;
+
+    @inject(ConnectionStatusService)
+    protected readonly connectionStatusService: ConnectionStatusService;
+
+    @inject(FrontendApplicationStateService)
+    protected readonly frontendApplicationStateService: FrontendApplicationStateService;
+
+    public initialize(): void {
+        this.workspaceService.root.then(root => {
+            this.hostedPluginServer.getHostedPlugin().then(pluginMetadata => {
+                if (pluginMetadata) {
+                    this.updateTitle(root);
+
+                    this.entry = {
+                        text: `$(cube) ${HostedPluginInformer.DEVELOPMENT_HOST_TITLE}`,
+                        tooltip: `Hosted Plugin '${pluginMetadata.model.name}'`,
+                        alignment: StatusBarAlignment.LEFT,
+                        priority: 100
+                    };
+
+                    this.frontendApplicationStateService.reachedState('ready').then(() => {
+                        this.updateStatusBarElement();
+                    });
+
+                    this.connectionStatusService.onStatusChange(() => this.updateStatusBarElement());
+                }
+            });
+        });
+    }
+
+    private updateStatusBarElement(): void {
+        if (this.connectionStatusService.currentState.state === ConnectionState.OFFLINE) {
+            this.entry.className = HostedPluginInformer.DEVELOPMENT_HOST_OFFLINE;
+        } else {
+            this.entry.className = HostedPluginInformer.DEVELOPMENT_HOST;
+        }
+
+        this.statusBar.setElement(HostedPluginInformer.DEVELOPMENT_HOST, this.entry);
+    }
+
+    private updateTitle(root: FileStat | undefined): void {
+        if (root) {
+            const uri = new URI(root.uri);
+            document.title = HostedPluginInformer.DEVELOPMENT_HOST_TITLE + " - " + uri.displayName;
+        } else {
+            document.title = HostedPluginInformer.DEVELOPMENT_HOST_TITLE;
+        }
+    }
+
+}

--- a/packages/plugin-ext/src/main/browser/hosted-plugin-controller.ts
+++ b/packages/plugin-ext/src/main/browser/hosted-plugin-controller.ts
@@ -1,0 +1,242 @@
+/*
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { injectable, inject } from 'inversify';
+import { StatusBar } from '@theia/core/lib/browser/status-bar/status-bar';
+import { StatusBarAlignment, StatusBarEntry, FrontendApplicationContribution } from '@theia/core/lib/browser';
+import { HostedPluginServer } from '../../common/plugin-protocol';
+import { HostedPluginManagerClient, HostedPluginState, HostedPluginCommands } from './plugin-manager-client';
+import { CommandRegistry } from "@phosphor/commands";
+import { Menu } from "@phosphor/widgets";
+import { setTimeout } from 'timers';
+import { FrontendApplicationStateService } from '@theia/core/lib/browser/frontend-application-state';
+import { ConnectionStatusService, ConnectionState } from '@theia/core/lib/browser/connection-status-service';
+
+/**
+ * Adds a status bar element displaying the state of secondary Theia instance with hosted plugin and
+ * allows controlling the instance by simple clicking on the status bar element.
+ */
+@injectable()
+export class HostedPluginController implements FrontendApplicationContribution {
+
+    public static readonly HOSTED_PLUGIN = "hosted-plugin";
+    public static readonly HOSTED_PLUGIN_OFFLINE = "hosted-plugin-offline";
+    public static readonly HOSTED_PLUGIN_FAILED = "hosted-plugin-failed";
+
+    @inject(StatusBar)
+    protected readonly statusBar: StatusBar;
+
+    @inject(FrontendApplicationStateService)
+    protected readonly frontendApplicationStateService: FrontendApplicationStateService;
+
+    @inject(HostedPluginServer)
+    protected readonly hostedPluginServer: HostedPluginServer;
+
+    @inject(HostedPluginManagerClient)
+    protected readonly hostedPluginManagerClient: HostedPluginManagerClient;
+
+    @inject(ConnectionStatusService)
+    protected readonly connectionStatusService: ConnectionStatusService;
+
+    private pluginState: HostedPluginState = 'stopped';
+
+    private entry: StatusBarEntry | undefined;
+
+    public initialize(): void {
+        this.hostedPluginServer.getHostedPlugin().then(pluginMetadata => {
+            if (!pluginMetadata) {
+                this.frontendApplicationStateService.reachedState('ready').then(() => {
+                    this.hostedPluginManagerClient.onStateChanged(e => {
+                        if (e === 'starting') {
+                            this.onHostedPluginStarting();
+                        } else if (e === 'running') {
+                            this.onHostedPluginRunning();
+                        } else if (e === 'stopped') {
+                            this.onHostedPluginStopped();
+                        } else if (e === 'failed') {
+                            this.onHostedPluginFailed();
+                        }
+                    });
+
+                    this.hostedPluginServer.isHostedTheiaRunning().then((running) => {
+                        if (running) {
+                            this.onHostedPluginRunning();
+                        }
+                    });
+                });
+
+                this.connectionStatusService.onStatusChange(() => this.onConnectionStatusChanged());
+            }
+        });
+    }
+
+    /**
+     * Display status bar element for stopped plugin.
+     */
+    protected async onHostedPluginStopped(): Promise<void> {
+        this.pluginState = 'stopped';
+
+        this.entry = {
+            text: `Hosted Plugin: Stopped $(angle-up)`,
+            alignment: StatusBarAlignment.LEFT,
+            priority: 100,
+            onclick: e => {
+                this.showMenu(e.clientX, e.clientY);
+            }
+        };
+
+        this.entry.className = HostedPluginController.HOSTED_PLUGIN;
+        await this.statusBar.setElement(HostedPluginController.HOSTED_PLUGIN, this.entry);
+    }
+
+    /**
+     * Display status bar element for starting plugin.
+     */
+    protected async onHostedPluginStarting(): Promise<void> {
+
+        this.pluginState = 'starting';
+
+        this.entry = {
+            text: `$(cog~spin) Hosted Plugin: Starting`,
+            alignment: StatusBarAlignment.LEFT,
+            priority: 100
+        };
+
+        this.entry.className = HostedPluginController.HOSTED_PLUGIN;
+        await this.statusBar.setElement(HostedPluginController.HOSTED_PLUGIN, this.entry);
+    }
+
+    /**
+     * Display status bar element for running plugin.
+     */
+    protected async onHostedPluginRunning(): Promise<void> {
+        this.pluginState = 'running';
+
+        this.entry = {
+            text: `$(cog~spin) Hosted Plugin: Running $(angle-up)`,
+            alignment: StatusBarAlignment.LEFT,
+            priority: 100,
+            onclick: e => {
+                this.showMenu(e.clientX, e.clientY);
+            }
+        };
+
+        this.entry.className = HostedPluginController.HOSTED_PLUGIN;
+        await this.statusBar.setElement(HostedPluginController.HOSTED_PLUGIN, this.entry);
+    }
+
+    /**
+     * Display status bar element for failed plugin.
+     */
+    protected async onHostedPluginFailed(): Promise<void> {
+        this.pluginState = 'failed';
+
+        this.entry = {
+            text: `Hosted Plugin: Stopped $(angle-up)`,
+            alignment: StatusBarAlignment.LEFT,
+            priority: 100,
+            onclick: e => {
+                this.showMenu(e.clientX, e.clientY);
+            }
+        };
+
+        this.entry.className = HostedPluginController.HOSTED_PLUGIN_FAILED;
+        await this.statusBar.setElement(HostedPluginController.HOSTED_PLUGIN, this.entry);
+    }
+
+    /**
+     * Updaing status bar element when changing connection status.
+     */
+    private onConnectionStatusChanged(): void {
+        if (this.connectionStatusService.currentState.state === ConnectionState.OFFLINE) {
+            // Re-set the element only if it's visible on status bar
+            if (this.entry) {
+                const offlineElement = {
+                    text: `Hosted Plugin: Stopped`,
+                    alignment: StatusBarAlignment.LEFT,
+                    priority: 100
+                };
+
+                this.entry.className = HostedPluginController.HOSTED_PLUGIN_OFFLINE;
+                this.statusBar.setElement(HostedPluginController.HOSTED_PLUGIN, offlineElement);
+            }
+        } else {
+            // ask state of hosted plugin when switching to Online
+            if (this.entry) {
+                this.hostedPluginServer.isHostedTheiaRunning().then((running) => {
+                    if (running) {
+                        this.onHostedPluginRunning();
+                    } else {
+                        this.onHostedPluginStopped();
+                    }
+                });
+            }
+        }
+    }
+
+    /**
+     * Show menu containing actions to start/stop/restart hosted plugin.
+     */
+    protected showMenu(x: number, y: number): void {
+        const commands = new CommandRegistry();
+        const menu = new Menu({
+            commands
+        });
+
+        if (this.pluginState === 'running') {
+            this.addCommandsForRunningPlugin(commands, menu);
+        } else if (this.pluginState === 'stopped' || this.pluginState === 'failed') {
+            this.addCommandsForStoppedPlugin(commands, menu);
+        }
+
+        menu.open(x, y);
+    }
+
+    /**
+     * Adds commands to the menu for running plugin.
+     */
+    protected addCommandsForRunningPlugin(commands: CommandRegistry, menu: Menu): void {
+        commands.addCommand(HostedPluginCommands.STOP.id, {
+            label: 'Stop Instance',
+            icon: 'fa fa-stop',
+            execute: () => setTimeout(() => this.hostedPluginManagerClient.stop(), 100)
+        });
+
+        menu.addItem({
+            type: 'command',
+            command: HostedPluginCommands.STOP.id
+        });
+
+        commands.addCommand(HostedPluginCommands.RESTART.id, {
+            label: 'Restart Instance',
+            icon: 'fa fa-repeat',
+            execute: () => setTimeout(() => this.hostedPluginManagerClient.restart(), 100)
+        });
+
+        menu.addItem({
+            type: 'command',
+            command: HostedPluginCommands.RESTART.id
+        });
+    }
+
+    /**
+     * Adds command to the menu for stopped plugin.
+     */
+    protected addCommandsForStoppedPlugin(commands: CommandRegistry, menu: Menu): void {
+        commands.addCommand(HostedPluginCommands.START.id, {
+            label: "Start Instance",
+            icon: 'fa fa-play',
+            execute: () => setTimeout(() => this.hostedPluginManagerClient.start(), 100)
+        });
+
+        menu.addItem({
+            type: 'command',
+            command: HostedPluginCommands.START.id
+        });
+    }
+
+}

--- a/packages/plugin-ext/src/main/browser/hosted-plugin-controller.ts
+++ b/packages/plugin-ext/src/main/browser/hosted-plugin-controller.ts
@@ -10,8 +10,8 @@ import { StatusBar } from '@theia/core/lib/browser/status-bar/status-bar';
 import { StatusBarAlignment, StatusBarEntry, FrontendApplicationContribution } from '@theia/core/lib/browser';
 import { HostedPluginServer } from '../../common/plugin-protocol';
 import { HostedPluginManagerClient, HostedPluginState, HostedPluginCommands } from './plugin-manager-client';
-import { CommandRegistry } from "@phosphor/commands";
-import { Menu } from "@phosphor/widgets";
+import { CommandRegistry } from '@phosphor/commands';
+import { Menu } from '@phosphor/widgets';
 import { setTimeout } from 'timers';
 import { FrontendApplicationStateService } from '@theia/core/lib/browser/frontend-application-state';
 import { ConnectionStatusService, ConnectionState } from '@theia/core/lib/browser/connection-status-service';
@@ -42,7 +42,7 @@ export class HostedPluginController implements FrontendApplicationContribution {
     @inject(ConnectionStatusService)
     protected readonly connectionStatusService: ConnectionStatusService;
 
-    private pluginState: HostedPluginState = 'stopped';
+    private pluginState: HostedPluginState = HostedPluginState.Stopped;
 
     private entry: StatusBarEntry | undefined;
 
@@ -78,7 +78,7 @@ export class HostedPluginController implements FrontendApplicationContribution {
      * Display status bar element for stopped plugin.
      */
     protected async onHostedPluginStopped(): Promise<void> {
-        this.pluginState = 'stopped';
+        this.pluginState = HostedPluginState.Stopped;
 
         this.entry = {
             text: `Hosted Plugin: Stopped $(angle-up)`,
@@ -97,8 +97,7 @@ export class HostedPluginController implements FrontendApplicationContribution {
      * Display status bar element for starting plugin.
      */
     protected async onHostedPluginStarting(): Promise<void> {
-
-        this.pluginState = 'starting';
+        this.pluginState = HostedPluginState.Starting;
 
         this.entry = {
             text: `$(cog~spin) Hosted Plugin: Starting`,
@@ -114,7 +113,7 @@ export class HostedPluginController implements FrontendApplicationContribution {
      * Display status bar element for running plugin.
      */
     protected async onHostedPluginRunning(): Promise<void> {
-        this.pluginState = 'running';
+        this.pluginState = HostedPluginState.Running;
 
         this.entry = {
             text: `$(cog~spin) Hosted Plugin: Running $(angle-up)`,
@@ -133,7 +132,7 @@ export class HostedPluginController implements FrontendApplicationContribution {
      * Display status bar element for failed plugin.
      */
     protected async onHostedPluginFailed(): Promise<void> {
-        this.pluginState = 'failed';
+        this.pluginState = HostedPluginState.Failed;
 
         this.entry = {
             text: `Hosted Plugin: Stopped $(angle-up)`,

--- a/packages/plugin-ext/src/main/browser/plugin-ext-frontend-module.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-ext-frontend-module.ts
@@ -4,6 +4,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
+
+import '../../../src/main/style/status-bar.css';
+
 import { ContainerModule } from "inversify";
 import { FrontendApplicationContribution, FrontendApplication, WidgetFactory, KeybindingContribution } from "@theia/core/lib/browser";
 import { MaybePromise, CommandContribution, MenuContribution } from "@theia/core/lib/common";
@@ -19,6 +22,9 @@ import { ModalNotification } from './dialogs/modal-notification';
 import { PluginWidget } from "./plugin-ext-widget";
 import { PluginFrontendViewContribution } from "./plugin-frontend-view-contribution";
 
+import { HostedPluginInformer } from "../../hosted/browser/hosted-plugin-informer";
+import { HostedPluginController } from "./hosted-plugin-controller";
+
 import '../../../src/main/browser/style/index.css';
 import { PluginExtDeployCommandService } from "./plugin-ext-deploy-command";
 
@@ -29,6 +35,9 @@ export default new ContainerModule(bind => {
     bind(HostedPluginSupport).toSelf().inSingletonScope();
     bind(HostedPluginWatcher).toSelf().inSingletonScope();
     bind(HostedPluginManagerClient).toSelf().inSingletonScope();
+
+    bind(FrontendApplicationContribution).to(HostedPluginInformer).inSingletonScope();
+    bind(FrontendApplicationContribution).to(HostedPluginController).inSingletonScope();
 
     bind(PluginApiFrontendContribution).toSelf().inSingletonScope();
     bind(FrontendApplicationContribution).toDynamicValue(c => c.container.get(PluginApiFrontendContribution));

--- a/packages/plugin-ext/src/main/browser/plugin-frontend-contribution.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-frontend-contribution.ts
@@ -20,16 +20,16 @@ export class PluginApiFrontendContribution implements CommandContribution {
     protected readonly pluginExtDeployCommandService: PluginExtDeployCommandService;
 
     registerCommands(commands: CommandRegistry): void {
-        commands.registerCommand(HostedPluginCommands.RUN, {
+        commands.registerCommand(HostedPluginCommands.START, {
             execute: () => this.hostedPluginManagerClient.start()
         });
-        commands.registerCommand(HostedPluginCommands.TERMINATE, {
+        commands.registerCommand(HostedPluginCommands.STOP, {
             execute: () => this.hostedPluginManagerClient.stop()
         });
         commands.registerCommand(HostedPluginCommands.RESTART, {
             execute: () => this.hostedPluginManagerClient.restart()
         });
-        commands.registerCommand(HostedPluginCommands.SELECT_PLUGIN_PATH, {
+        commands.registerCommand(HostedPluginCommands.SELECT_PATH, {
             execute: () => this.hostedPluginManagerClient.selectPluginPath()
         });
 

--- a/packages/plugin-ext/src/main/browser/plugin-manager-client.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-manager-client.ts
@@ -7,13 +7,45 @@
 
 import { injectable, inject } from 'inversify';
 import URI from '@theia/core/lib/common/uri';
-import { MessageService, Command } from '@theia/core/lib/common';
+import { MessageService, Command, Emitter, Event } from '@theia/core/lib/common';
 import { LabelProvider, isNative } from '@theia/core/lib/browser';
 import { WindowService } from '@theia/core/lib/browser/window/window-service';
 import { WorkspaceService } from '@theia/workspace/lib/browser';
 import { FileSystem } from '@theia/filesystem/lib/common';
 import { FileDialogFactory, DirNode } from '@theia/filesystem/lib/browser';
 import { HostedPluginServer } from '../../common/plugin-protocol';
+
+/**
+ * Commands to control Hosted plugin instances.
+ */
+export namespace HostedPluginCommands {
+    export const START: Command = {
+        id: 'hosted-plugin:start',
+        label: 'Hosted Plugin: Start Instance'
+    };
+    export const STOP: Command = {
+        id: 'hosted-plugin:stop',
+        label: 'Hosted Plugin: Stop Instance'
+    };
+    export const RESTART: Command = {
+        id: 'hosted-plugin:restart',
+        label: 'Hosted Plugin: Restart Instance'
+    };
+    export const SELECT_PATH: Command = {
+        id: 'hosted-plugin:select-path',
+        label: 'Hosted Plugin: Select Path'
+    };
+}
+
+/**
+ * Available states of hosted plugin instance.
+ */
+export type HostedPluginState =
+    'stopped'
+    | 'starting'
+    | 'running'
+    | 'stopping'
+    | 'failed';
 
 /**
  * Responsible for UI to set up and control Hosted Plugin Instance.
@@ -35,8 +67,17 @@ export class HostedPluginManagerClient {
     @inject(WorkspaceService)
     protected readonly workspaceService: WorkspaceService;
 
+    // path to the plugin on the file system
     protected pluginLocation: URI | undefined;
-    protected pluginInstanceUri: string | undefined;
+
+    // URL to the running plugin instance
+    protected pluginInstanceURL: string | undefined;
+
+    protected readonly stateChanged = new Emitter<HostedPluginState>();
+
+    get onStateChanged(): Event<HostedPluginState> {
+        return this.stateChanged.event;
+    }
 
     async start(): Promise<void> {
         if (!this.pluginLocation) {
@@ -46,19 +87,28 @@ export class HostedPluginManagerClient {
                 return;
             }
         }
+
         try {
+            this.stateChanged.fire('starting');
             this.messageService.info('Starting hosted instance server ...');
-            await this.doRunRequest(this.pluginLocation);
-            this.messageService.info('Hosted instance is running at: ' + this.pluginInstanceUri);
+
+            this.pluginInstanceURL = await this.hostedPluginServer.runHostedPluginInstance(this.pluginLocation.toString());
+            await this.openPluginWindow();
+
+            this.messageService.info('Hosted instance is running at: ' + this.pluginInstanceURL);
+            this.stateChanged.fire('running');
         } catch (error) {
             this.messageService.error('Failed to run hosted plugin instance: ' + this.getErrorMessage(error));
+            this.stateChanged.fire('failed');
         }
     }
 
     async stop(): Promise<void> {
         try {
+            this.stateChanged.fire('stopping');
             await this.hostedPluginServer.terminateHostedPluginInstance();
-            this.messageService.info((this.pluginInstanceUri ? this.pluginInstanceUri : 'The instance') + ' has been terminated.');
+            this.messageService.info((this.pluginInstanceURL ? this.pluginInstanceURL : 'The instance') + ' has been terminated.');
+            this.stateChanged.fire('stopped');
         } catch (error) {
             this.messageService.warn(this.getErrorMessage(error));
         }
@@ -69,13 +119,17 @@ export class HostedPluginManagerClient {
             await this.stop();
 
             this.messageService.info('Starting hosted instance server ...');
+
             // It takes some time before OS released all resources e.g. port.
             // Keeping tries to run hosted instance with delay.
+            this.stateChanged.fire('starting');
             let lastError;
             for (let tries = 0; tries < 15; tries++) {
                 try {
-                    await this.doRunRequest(this.pluginLocation!);
-                    this.messageService.info('Hosted instance is running at: ' + this.pluginInstanceUri);
+                    this.pluginInstanceURL = await this.hostedPluginServer.runHostedPluginInstance(this.pluginLocation!.toString());
+                    await this.openPluginWindow();
+                    this.messageService.info('Hosted instance is running at: ' + this.pluginInstanceURL);
+                    this.stateChanged.fire('running');
                     return;
                 } catch (error) {
                     lastError = error;
@@ -86,6 +140,8 @@ export class HostedPluginManagerClient {
         } else {
             this.messageService.warn('Hosted Plugin instance is not running.');
         }
+
+        this.stateChanged.fire('failed');
     }
 
     /**
@@ -105,7 +161,7 @@ export class HostedPluginManagerClient {
         const name = this.labelProvider.getName(rootUri);
         const label = await this.labelProvider.getIcon(root);
         const rootNode = DirNode.createRoot(rootStat, name, label);
-        const dialog = this.fileDialogFactory({ title: HostedPluginCommands.SELECT_PLUGIN_PATH.label! });
+        const dialog = this.fileDialogFactory({ title: HostedPluginCommands.SELECT_PATH.label! });
         dialog.model.navigateTo(rootNode);
         const node = await dialog.open();
         if (node) {
@@ -119,20 +175,19 @@ export class HostedPluginManagerClient {
     }
 
     /**
-     * Send run command to backend. Throws an error if start failed.
-     * Sets hosted instance uri into pluginInstanceUri field.
-     *
-     * @param pluginLocation uri to plugin binaries
+     * Opens window with URL to the running plugin instance.
      */
-    protected async doRunRequest(pluginLocation: URI): Promise<void> {
-        const uri = await this.hostedPluginServer.runHostedPluginInstance(pluginLocation.toString());
-        this.pluginInstanceUri = uri;
-        if (!isNative) {
-            // Open a new tab in case of browser
+    protected async openPluginWindow(): Promise<void> {
+        // do nothing for electron browser
+        if (isNative) {
+            return;
+        }
+
+        if (this.pluginInstanceURL) {
             try {
-                this.windowService.openNewWindow(uri);
+                this.windowService.openNewWindow(this.pluginInstanceURL);
             } catch (err) {
-                this.messageService.warn('Your browser prevented opening of new tab. You can do it manually: ' + uri);
+                this.messageService.warn('Your browser prevented opening of new tab. You can do it manually: ' + this.pluginInstanceURL);
             }
         }
     }
@@ -140,23 +195,4 @@ export class HostedPluginManagerClient {
     protected getErrorMessage(error: Error): string {
         return error.message.substring(error.message.indexOf(':') + 1);
     }
-}
-
-export namespace HostedPluginCommands {
-    export const RUN: Command = {
-        id: 'hosted-plugin:run',
-        label: 'Hosted Plugin: Start Instance'
-    };
-    export const TERMINATE: Command = {
-        id: 'hosted-plugin:terminate',
-        label: 'Hosted Plugin: Stop Instance'
-    };
-    export const RESTART: Command = {
-        id: 'hosted-plugin:restart',
-        label: 'Hosted Plugin: Restart Instance'
-    };
-    export const SELECT_PLUGIN_PATH: Command = {
-        id: 'hosted-plugin:select-path',
-        label: 'Hosted Plugin: Select Path'
-    };
 }

--- a/packages/plugin-ext/src/main/browser/plugin-manager-client.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-manager-client.ts
@@ -40,12 +40,13 @@ export namespace HostedPluginCommands {
 /**
  * Available states of hosted plugin instance.
  */
-export type HostedPluginState =
-    'stopped'
-    | 'starting'
-    | 'running'
-    | 'stopping'
-    | 'failed';
+export enum HostedPluginState {
+    Stopped = 'stopped',
+    Starting = 'starting',
+    Running = 'running',
+    Stopping = 'stopping',
+    Failed = 'failed'
+}
 
 /**
  * Responsible for UI to set up and control Hosted Plugin Instance.
@@ -89,26 +90,26 @@ export class HostedPluginManagerClient {
         }
 
         try {
-            this.stateChanged.fire('starting');
+            this.stateChanged.fire(HostedPluginState.Starting);
             this.messageService.info('Starting hosted instance server ...');
 
             this.pluginInstanceURL = await this.hostedPluginServer.runHostedPluginInstance(this.pluginLocation.toString());
             await this.openPluginWindow();
 
             this.messageService.info('Hosted instance is running at: ' + this.pluginInstanceURL);
-            this.stateChanged.fire('running');
+            this.stateChanged.fire(HostedPluginState.Running);
         } catch (error) {
             this.messageService.error('Failed to run hosted plugin instance: ' + this.getErrorMessage(error));
-            this.stateChanged.fire('failed');
+            this.stateChanged.fire(HostedPluginState.Failed);
         }
     }
 
     async stop(): Promise<void> {
         try {
-            this.stateChanged.fire('stopping');
+            this.stateChanged.fire(HostedPluginState.Stopping);
             await this.hostedPluginServer.terminateHostedPluginInstance();
             this.messageService.info((this.pluginInstanceURL ? this.pluginInstanceURL : 'The instance') + ' has been terminated.');
-            this.stateChanged.fire('stopped');
+            this.stateChanged.fire(HostedPluginState.Stopped);
         } catch (error) {
             this.messageService.warn(this.getErrorMessage(error));
         }
@@ -122,14 +123,14 @@ export class HostedPluginManagerClient {
 
             // It takes some time before OS released all resources e.g. port.
             // Keeping tries to run hosted instance with delay.
-            this.stateChanged.fire('starting');
+            this.stateChanged.fire(HostedPluginState.Starting);
             let lastError;
             for (let tries = 0; tries < 15; tries++) {
                 try {
                     this.pluginInstanceURL = await this.hostedPluginServer.runHostedPluginInstance(this.pluginLocation!.toString());
                     await this.openPluginWindow();
                     this.messageService.info('Hosted instance is running at: ' + this.pluginInstanceURL);
-                    this.stateChanged.fire('running');
+                    this.stateChanged.fire(HostedPluginState.Running);
                     return;
                 } catch (error) {
                     lastError = error;
@@ -141,7 +142,7 @@ export class HostedPluginManagerClient {
             this.messageService.warn('Hosted Plugin instance is not running.');
         }
 
-        this.stateChanged.fire('failed');
+        this.stateChanged.fire(HostedPluginState.Failed);
     }
 
     /**

--- a/packages/plugin-ext/src/main/style/status-bar.css
+++ b/packages/plugin-ext/src/main/style/status-bar.css
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#theia-statusBar .development-host {
+    background-color: var(--theia-success-color0);
+}
+
+#theia-statusBar .development-host-offline {
+    background-color: var(--theia-error-color0);
+}
+
+#theia-statusBar .hosted-plugin {
+    background-color: var(--theia-info-color0);
+}
+
+#theia-statusBar .hosted-plugin:hover {
+    background-color: var(--theia-info-color1);
+}
+
+#theia-statusBar .hosted-plugin-failed {
+    background-color: var(--theia-error-color0);
+}


### PR DESCRIPTION
Adds a status bar element displaying the state of Theia instance with hosted plugin.
Adds a status bar element notifying that Theia is running in dev mode with hosted plugin.

Issues to be resolved
Add info about Dev mode instance to the main Theia one https://github.com/eclipse/che/issues/9402
Add UI to differ developer mode in Theia https://github.com/eclipse/che/issues/9214

![screenshot from 2018-05-11 17-56-33](https://user-images.githubusercontent.com/1655894/39930937-ae598ff8-5544-11e8-82c0-34823df2ed95.png)

![screenshot from 2018-05-11 17-57-03](https://user-images.githubusercontent.com/1655894/39930961-bb052a8c-5544-11e8-8d0b-758abd8133f4.png)

![screenshot from 2018-05-11 17-57-24](https://user-images.githubusercontent.com/1655894/39930977-c622a5ca-5544-11e8-95e4-a8d85fea42fc.png)

![39516426-9f13191a-4e05-11e8-960a-774bf6c132c5 1](https://user-images.githubusercontent.com/1655894/39931006-db0ec392-5544-11e8-88a3-b14702a6f003.png)

![39516435-a15ccefa-4e05-11e8-9fc7-c1835e94d609](https://user-images.githubusercontent.com/1655894/39931012-dd457ebc-5544-11e8-9190-90732fedcc64.png)



