### PR TITLE
Make HostedPluginUriPostProcessor symbol global

### DIFF
--- a/packages/plugin-ext/src/hosted/node/hosted-plugin-manager.ts
+++ b/packages/plugin-ext/src/hosted/node/hosted-plugin-manager.ts
@@ -11,7 +11,7 @@ import * as fs from "fs";
 import * as net from "net";
 import URI from '@theia/core/lib/common/uri';
 import { ContributionProvider } from "@theia/core/lib/common/contribution-provider";
-import { HostedPluginUriPostProcessor } from "./hosted-plugin-uri-postprocessor";
+import { HostedPluginUriPostProcessor, HostedPluginUriPostProcessorSymbolName } from "./hosted-plugin-uri-postprocessor";
 
 export const HostedPluginManager = Symbol('HostedPluginManager');
 
@@ -198,7 +198,7 @@ export abstract class AbstractHostedPluginManager implements HostedPluginManager
 
 @injectable()
 export class NodeHostedPluginRunner extends AbstractHostedPluginManager {
-    @inject(ContributionProvider) @named(HostedPluginUriPostProcessor)
+    @inject(ContributionProvider) @named(Symbol.for(HostedPluginUriPostProcessorSymbolName))
     protected readonly uriPostProcessors: ContributionProvider<HostedPluginUriPostProcessor>;
 
     protected async postProcessInstanceUri(uri: URI): Promise<URI> {

--- a/packages/plugin-ext/src/hosted/node/hosted-plugin-uri-postprocessor.ts
+++ b/packages/plugin-ext/src/hosted/node/hosted-plugin-uri-postprocessor.ts
@@ -7,7 +7,16 @@
 
 import URI from "@theia/core/lib/common/uri";
 
-export const HostedPluginUriPostProcessor = Symbol('HostedPluginUriPostProcessor');
+// We export symbol name instead of symbol itself here because we need to provide
+// a contribution point to which any extensions could contribute.
+// In case of just symbols, symbol inside an extension won't be the same as here
+// even if the extension imports this module.
+// To solve this problem we should provide global symbol. So right way to use the contribution point is:
+// ...
+// bind(Symbol.for(HostedPluginUriPostProcessorSymbolName)).to(AContribution);
+// ...
+export const HostedPluginUriPostProcessorSymbolName = 'HostedPluginUriPostProcessor';
+
 export interface HostedPluginUriPostProcessor {
     processUri(uri: URI): Promise<URI>;
 }

--- a/packages/plugin-ext/src/hosted/node/plugin-ext-hosted-backend-module.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-ext-hosted-backend-module.ts
@@ -7,7 +7,7 @@
 
 import { bindContributionProvider } from "@theia/core/lib/common/contribution-provider";
 import { HostedPluginManager, NodeHostedPluginRunner } from './hosted-plugin-manager';
-import { HostedPluginUriPostProcessor } from "./hosted-plugin-uri-postprocessor";
+import { HostedPluginUriPostProcessorSymbolName } from "./hosted-plugin-uri-postprocessor";
 import { interfaces } from "inversify";
 import { ConnectionHandler, JsonRpcConnectionHandler } from "@theia/core/lib/common/messaging";
 import { BackendApplicationContribution } from '@theia/core/lib/node/backend-application';
@@ -41,6 +41,6 @@ export function bindCommonHostedBackend(bind: interfaces.Bind): void {
 
 export function bindHostedBackend(bind: interfaces.Bind): void {
     bind(HostedPluginManager).to(NodeHostedPluginRunner).inSingletonScope();
-    bindContributionProvider(bind, HostedPluginUriPostProcessor);
+    bindContributionProvider(bind, Symbol.for(HostedPluginUriPostProcessorSymbolName));
     bindCommonHostedBackend(bind);
 }


### PR DESCRIPTION
Makes HostedPluginUriPostProcessor symbol global to extensions be able to contribute.

This is experimental changes. We have problems with symbols, when an extension tries to use a symbol from core (via import), but the original and imported one are two different symbols.
If it won't work due to some reasons, I'll revert it.