### PR TITLE
Add dev dependency to @theia/plugin module from @theia/plugin-ext

### DIFF
--- a/packages/plugin-ext/package.json
+++ b/packages/plugin-ext/package.json
@@ -46,6 +46,7 @@
   },
   "devDependencies": {
     "@theia/ext-scripts": "^0.3.10",
+    "@theia/plugin": "^0.3.10",
     "@types/decompress": "^4.2.2"
   },
   "nyc": {


### PR DESCRIPTION
Adds dependency for `@theia/plugin` into `@theia/plugin-ext`
`@theia/plugin-ext` directly depends on `@theia/plugin` but hasn't it as a dependency. Theia build isn't failed only because some circumstances (like caches entry of `@theia/plugin`). But when other extension depends on `@theia/plugin-ext` (to contribute into it) such wrong behaviour causes problems.