### PR TITLE
Moves @theia/plugin dependency from dev to main in @theia/plugin-ext

### DIFF
--- a/packages/plugin-ext/package.json
+++ b/packages/plugin-ext/package.json
@@ -8,6 +8,7 @@
     "@theia/core": "^0.3.10",
     "@theia/filesystem": "^0.3.10",
     "@theia/workspace": "^0.3.10",
+    "@theia/plugin": "^0.3.10",
     "decompress": "^4.2.0"
   },
   "publishConfig": {
@@ -46,7 +47,6 @@
   },
   "devDependencies": {
     "@theia/ext-scripts": "^0.3.10",
-    "@theia/plugin": "^0.3.10",
     "@types/decompress": "^4.2.2"
   },
   "nyc": {

--- a/packages/plugin-ext/src/common/index.ts
+++ b/packages/plugin-ext/src/common/index.ts
@@ -8,6 +8,8 @@
 // Exports contribution point for uri postprocessor of hosted plugin manager.
 // This could be used to alter hosted instance uri, for example, change port.
 export * from '../hosted/node/hosted-plugin-uri-postprocessor';
+
+// Here we expose types from @theia/plugin, so it becames a direct dependency
 export * from '../common/plugin-protocol';
 export * from '../plugin/plugin-context';
 export * from '../api/plugin-api';


### PR DESCRIPTION
Adding @theia/plugin dependency into dev dependencies didn't help, so we have to add it into dependencies.