### PR TITLE
Add support for vscode:extension/ resolver and http(s):// resolver

### DIFF
--- a/packages/plugin-ext-vscode/src/node/plugin-vscode-backend-module.ts
+++ b/packages/plugin-ext-vscode/src/node/plugin-vscode-backend-module.ts
@@ -17,6 +17,5 @@ export default new ContainerModule(bind => {
     bind(PluginDeployerDirectoryHandler).to(PluginVsCodeDirectoryHandler).inSingletonScope();
     bind(PluginScanner).to(VsCodePluginScanner).inSingletonScope();
     bind(PluginDeployerResolver).to(VsCodePluginDeployerResolver).inSingletonScope();
-
 }
 );

--- a/packages/plugin-ext-vscode/src/node/plugin-vscode-backend-module.ts
+++ b/packages/plugin-ext-vscode/src/node/plugin-vscode-backend-module.ts
@@ -6,14 +6,17 @@
  */
 
 import { ContainerModule } from 'inversify';
-import { PluginDeployerFileHandler, PluginDeployerDirectoryHandler, PluginScanner } from "@theia/plugin-ext";
+import { PluginDeployerFileHandler, PluginDeployerDirectoryHandler, PluginScanner, PluginDeployerResolver } from "@theia/plugin-ext";
 import { PluginVsCodeFileHandler } from "./plugin-vscode-file-handler";
 import { PluginVsCodeDirectoryHandler } from "./plugin-vscode-directory-handler";
 import { VsCodePluginScanner } from "./scanner-vscode";
+import { VsCodePluginDeployerResolver } from './plugin-vscode-resolver';
 
 export default new ContainerModule(bind => {
     bind(PluginDeployerFileHandler).to(PluginVsCodeFileHandler).inSingletonScope();
     bind(PluginDeployerDirectoryHandler).to(PluginVsCodeDirectoryHandler).inSingletonScope();
     bind(PluginScanner).to(VsCodePluginScanner).inSingletonScope();
+    bind(PluginDeployerResolver).to(VsCodePluginDeployerResolver).inSingletonScope();
+
 }
 );

--- a/packages/plugin-ext-vscode/src/node/plugin-vscode-resolver.ts
+++ b/packages/plugin-ext-vscode/src/node/plugin-vscode-resolver.ts
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { PluginDeployerResolver, PluginDeployerResolverContext } from "@theia/plugin-ext";
+import { injectable } from "inversify";
+import * as request from "request";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+/**
+ * Resolver that handle the vscode: protocol
+ */
+@injectable()
+export class VsCodePluginDeployerResolver implements PluginDeployerResolver {
+
+    private static PREFIX = 'vscode:extension/';
+
+    private static MARKET_PLACE_ENDPOINT = 'https://marketplace.visualstudio.com/_apis/public/gallery/extensionquery';
+
+    private static HEADERS = {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json;api-version=3.0-preview.1'
+    };
+
+    private unpackedFolder: string;
+    constructor() {
+        this.unpackedFolder = path.resolve(os.tmpdir(), 'vscode-extension-marketplace');
+        if (!fs.existsSync(this.unpackedFolder)) {
+            fs.mkdirSync(this.unpackedFolder);
+        }
+    }
+
+    /**
+     * Download vscode extensions if available and add them as plugins.
+     */
+    async resolve(pluginResolverContext: PluginDeployerResolverContext): Promise<void> {
+
+        // download the file
+        return new Promise<void>((resolve, reject) => {
+            // extract name
+            const extracted = /^vscode:extension\/(.*)/gm.exec(pluginResolverContext.getOriginId());
+
+            if (!extracted || extracted === null) {
+                reject('Invalid extension' + pluginResolverContext.getOriginId());
+                return;
+            }
+            const extensionName = extracted[1];
+            const wantedExtensionVersion = null;
+
+            const json = {
+                "filters": [{
+                    "criteria": [{ "filterType": 7, "value": extensionName }], "pageNumber": 1,
+                    "pageSize": 1, "sortBy": 0, "sortOrder": 0
+                }], "assetTypes": ["Microsoft.VisualStudio.Services.VSIXPackage"],
+                "flags": 131
+            };
+
+            const options = {
+                url: VsCodePluginDeployerResolver.MARKET_PLACE_ENDPOINT,
+                headers: VsCodePluginDeployerResolver.HEADERS,
+                method: 'POST',
+                json: json
+            };
+
+            request(options, (error, response, body) => {
+                if (error) {
+                    reject(error);
+                } else if (response.statusCode === 200) {
+                    const extension = body.results[0].extensions[0];
+                    if (!extension) {
+                        reject('No extension');
+                    }
+                    let asset;
+                    if (wantedExtensionVersion !== null) {
+                        const extensionVersion = extension.versions.filter((value: any) => value.version === '0.0.1')[0];
+                        asset = extensionVersion.files.filter((f: any) => f.assetType === 'Microsoft.VisualStudio.Services.VSIXPackage')[0];
+                    } else {
+                        // take first one
+                        asset = extension.versions[0].files.filter((f: any) => f.assetType === 'Microsoft.VisualStudio.Services.VSIXPackage')[0];
+                    }
+                    const shortName = pluginResolverContext.getOriginId().replace(/\W/g, '_');
+                    const unpackedPath = path.resolve(this.unpackedFolder, path.basename(shortName + '.vsix'));
+                    const finish = () => {
+                        pluginResolverContext.addPlugin(pluginResolverContext.getOriginId(), unpackedPath);
+                        resolve();
+                    };
+
+                    const dest = fs.createWriteStream(unpackedPath);
+                    dest.addListener('finish', finish);
+
+                    request.get(asset.source)
+                        .on('error', (err) => {
+                            reject(err);
+                        }).pipe(dest);
+                } else {
+                    reject(new Error('Invalid status code' + response.statusCode + ' and message is ' + response.statusMessage));
+                }
+            });
+        });
+
+    }
+
+    /**
+     * Handle only the plugins that starts with vscode:
+     */
+    accept(pluginId: string): boolean {
+        return pluginId.startsWith(VsCodePluginDeployerResolver.PREFIX);
+    }
+}

--- a/packages/plugin-ext/src/main/node/plugin-ext-backend-module.ts
+++ b/packages/plugin-ext/src/main/node/plugin-ext-backend-module.ts
@@ -15,6 +15,7 @@ import { LocalDirectoryPluginDeployerResolver } from "./resolvers/plugin-local-d
 import { PluginTheiaFileHandler } from "./handlers/plugin-theia-file-handler";
 import { PluginTheiaDirectoryHandler } from "./handlers/plugin-theia-directory-handler";
 import { GithubPluginDeployerResolver } from "./plugin-github-resolver";
+import { HttpPluginDeployerResolver } from "./plugin-http-resolver";
 
 export function bindMainBackend(bind: interfaces.Bind): void {
     bind(PluginApiContribution).toSelf().inSingletonScope();
@@ -26,6 +27,8 @@ export function bindMainBackend(bind: interfaces.Bind): void {
 
     bind(PluginDeployerResolver).to(LocalDirectoryPluginDeployerResolver).inSingletonScope();
     bind(PluginDeployerResolver).to(GithubPluginDeployerResolver).inSingletonScope();
+    bind(PluginDeployerResolver).to(HttpPluginDeployerResolver).inSingletonScope();
+
     bind(PluginDeployerFileHandler).to(PluginTheiaFileHandler).inSingletonScope();
     bind(PluginDeployerDirectoryHandler).to(PluginTheiaDirectoryHandler).inSingletonScope();
 }

--- a/packages/plugin-ext/src/main/node/plugin-http-resolver.ts
+++ b/packages/plugin-ext/src/main/node/plugin-http-resolver.ts
@@ -49,17 +49,7 @@ export class HttpPluginDeployerResolver implements PluginDeployerResolver {
 
             const dirname = path.dirname(link.pathname);
             const basename = path.basename(link.pathname);
-            console.log('basename is', basename);
-            console.log('dirname is', dirname);
-
             const filename = dirname.replace(/\W/g, '_') + ('-') + basename;
-            console.log('filename is', filename);
-            console.log('dirname is', dirname);
-            /*
-                        let filename = parsed.pathname pluginResolverContext.getOriginId().replace(/\W/g, '_');
-                        if (filename.endsWith('theia')) {
-                            filename = filename + '.theia';
-                        }*/
             const unpackedPath = path.resolve(this.unpackedFolder, path.basename(filename));
 
             const finish = () => {

--- a/packages/plugin-ext/src/main/node/plugin-http-resolver.ts
+++ b/packages/plugin-ext/src/main/node/plugin-http-resolver.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2018 Red Hat, Inc. and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { injectable } from "inversify";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import * as url from "url";
+import * as request from "request";
+
+import { PluginDeployerResolver, PluginDeployerResolverContext } from "../../common";
+
+/**
+ * Resolver that handle the http(s): protocol
+ * http://path/to/my.plugin
+ * https://path/to/my.plugin
+ */
+@injectable()
+export class HttpPluginDeployerResolver implements PluginDeployerResolver {
+
+    private unpackedFolder: string;
+
+    constructor() {
+        this.unpackedFolder = path.resolve(os.tmpdir(), 'http-remote');
+        if (!fs.existsSync(this.unpackedFolder)) {
+            fs.mkdirSync(this.unpackedFolder);
+        }
+    }
+
+    /**
+     * Grab the remote file specified by the given URL
+     */
+    async resolve(pluginResolverContext: PluginDeployerResolverContext): Promise<void> {
+
+        // download the file
+        return new Promise<void>((resolve, reject) => {
+
+            // keep filename of the url
+            const urlPath = pluginResolverContext.getOriginId();
+            const link = url.parse(urlPath);
+            if (!link.pathname) {
+                reject('invalid link URI' + urlPath);
+                return;
+            }
+
+            const dirname = path.dirname(link.pathname);
+            const basename = path.basename(link.pathname);
+            console.log('basename is', basename);
+            console.log('dirname is', dirname);
+
+            const filename = dirname.replace(/\W/g, '_') + ('-') + basename;
+            console.log('filename is', filename);
+            console.log('dirname is', dirname);
+            /*
+                        let filename = parsed.pathname pluginResolverContext.getOriginId().replace(/\W/g, '_');
+                        if (filename.endsWith('theia')) {
+                            filename = filename + '.theia';
+                        }*/
+            const unpackedPath = path.resolve(this.unpackedFolder, path.basename(filename));
+
+            const finish = () => {
+                pluginResolverContext.addPlugin(pluginResolverContext.getOriginId(), unpackedPath);
+                resolve();
+            };
+
+            // use of cache. If file is already there use it directly
+            if (fs.existsSync(unpackedPath)) {
+                finish();
+                return;
+            }
+            const dest = fs.createWriteStream(unpackedPath);
+
+            dest.addListener('finish', finish);
+            request.get(pluginResolverContext.getOriginId())
+                .on('error', (err) => {
+                    reject(err);
+                }).pipe(dest);
+        });
+
+    }
+
+    /**
+     * Handle only the plugins that starts with http or https:
+     */
+    accept(pluginId: string): boolean {
+        return /^http[s]?:\/\/.*$/gm.test(pluginId);
+    }
+}


### PR DESCRIPTION
Allow to grab some vscode extension or download files hosted on a http(s) server

![theia-vscode](https://user-images.githubusercontent.com/436777/40180203-8eb50528-59e6-11e8-914b-32de1d1253af.gif)
